### PR TITLE
The context.options of a roll is not always guaranteed to be a Set. S…

### DIFF
--- a/src/roll.js
+++ b/src/roll.js
@@ -8,6 +8,8 @@ import { getVisibility } from './token.js'
 export async function checkRoll(wrapped, ...args) {
     const context = args[1]
     if (!context) return wrapped(...args)
+    // System code must pass a set, but macros and modules may instead pass an array
+    if (Array.isArray(context.options)) context.options = new Set(context.options);
 
     const { actor, createMessage = 'true', type, token, target, isReroll } = context
     const originToken = token ?? getActorToken(actor)


### PR DESCRIPTION
…ee src/module/system/check/check.ts:63 in the pf2e system.

One macro that does this is Symon's Lingering Heroics macro (https://gitlab.com/symonsch/my-foundryvtt-macros/-/blob/main/PF2e/Lingering%20Heroics.js) but I'm sure there are others.